### PR TITLE
Remove regexes for more robust task finding

### DIFF
--- a/app/controllers/web_rake/tasks_controller.rb
+++ b/app/controllers/web_rake/tasks_controller.rb
@@ -104,11 +104,9 @@ module WebRake
 
       # Find the task
       task = Rake::Task[task_name] rescue nil
-      return nil unless task
 
       # Check if it's db:seed or defined in lib/tasks
-      return task if task_name == 'db:seed'
-      return task if task_from_lib_tasks?(task)
+      return task if task_from_lib_tasks?(task) || task_name == "db:seed"
 
       nil
     end

--- a/app/controllers/web_rake/tasks_controller.rb
+++ b/app/controllers/web_rake/tasks_controller.rb
@@ -84,17 +84,11 @@ module WebRake
 
       tasks = []
 
-      # Always include db:seed
-      if (seed_task = Rake::Task['db:seed'] rescue nil)
-        tasks << seed_task
-      end
-
-      # Find tasks defined in lib/tasks by checking their source location
+      # Find tasks defined in lib/tasks or db:seed
       Rake.application.tasks.each do |task|
         next if task.actions.blank?
-        next if task.name == 'db:seed' # Already added above
 
-        if task_from_lib_tasks?(task)
+        if task_from_lib_tasks?(task) || task.name == "db:seed"
           tasks << task
         end
       end
@@ -123,9 +117,7 @@ module WebRake
       return false if task.actions.blank?
 
       source_path = task.actions.first.source_location&.first
-      source_path.present? &&
-        source_path.include?(Rails.root.to_s) &&
-        source_path.include?('/lib/tasks/')
+      source_path.present? && source_path.include?(Rails.root.join("lib/tasks").to_s)
     end
   end
 end

--- a/app/controllers/web_rake/tasks_controller.rb
+++ b/app/controllers/web_rake/tasks_controller.rb
@@ -18,9 +18,8 @@ module WebRake
     def execute
       task_name = params[:id].gsub('__', ':')
 
-      # Check if this is one of our allowed tasks (custom tasks + db:seed)
-      allowed_tasks = extract_task_names_from_files + ['db:seed']
-      unless allowed_tasks.include?(task_name)
+      # Use find_task to validate the task is allowed
+      unless find_task
         redirect_to root_path, alert: "Task not found"
         return
       end
@@ -80,81 +79,53 @@ module WebRake
     end
 
     def custom_tasks
-      # First, get the names of tasks defined in lib/tasks files
-      custom_task_names = extract_task_names_from_files
-
-      # Always include db:seed task
-      custom_task_names << 'db:seed'
-
       # Ensure all tasks are loaded
       Rails.application.load_tasks
 
-      # Get only the tasks that match our custom task names
-      custom_task_names.filter_map do |name|
-        Rake::Task[name] rescue nil
-      end.select(&:actions)
-    end
+      tasks = []
 
-    def extract_task_names_from_files
-      task_names = []
+      # Always include db:seed
+      if (seed_task = Rake::Task['db:seed'] rescue nil)
+        tasks << seed_task
+      end
 
-      # Parse each rake file to extract task names
-      Dir.glob(Rails.root.join('lib/tasks/**/*.rake')).each do |file|
-        content = File.read(file)
+      # Find tasks defined in lib/tasks by checking their source location
+      Rake.application.tasks.each do |task|
+        next if task.actions.blank?
+        next if task.name == 'db:seed' # Already added above
 
-        # Match various task definition patterns
-
-        # Pattern for: task({ :sample_data => :environment })
-        content.scan(/task\s*\(\s*\{\s*:([a-zA-Z_][a-zA-Z0-9_]*)\s*=>/).each do |match|
-          task_names << match[0]
-        end
-
-        # Pattern for: task({ sample_data: :environment }) - Ruby 1.9+ syntax with parens and braces
-        content.scan(/task\s*\(\s*\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:/).each do |match|
-          task_names << match[0]
-        end
-
-        # Pattern for: task :sample_data => :environment
-        content.scan(/task\s+:([a-zA-Z_][a-zA-Z0-9_]*)\s*=>/).each do |match|
-          task_names << match[0]
-        end
-
-        # Pattern for: task "sample_data" => :environment
-        content.scan(/task\s+["']([a-zA-Z_][a-zA-Z0-9_]*)["']\s*=>/).each do |match|
-          task_names << match[0]
-        end
-
-        # Pattern for: task sample_data: :environment (Ruby 1.9+ syntax)
-        content.scan(/task\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*:/).each do |match|
-          task_names << match[0]
-        end
-
-        # Pattern for: task(:sample_data)
-        content.scan(/task\s*\(\s*:([a-zA-Z_][a-zA-Z0-9_]*)\s*\)/).each do |match|
-          task_names << match[0]
-        end
-
-        # Pattern for: desc "..." \n task :name
-        content.scan(/desc\s+.*?\n\s*task\s+:([a-zA-Z_][a-zA-Z0-9_]*)/).each do |match|
-          task_names << match[0]
+        if task_from_lib_tasks?(task)
+          tasks << task
         end
       end
 
-      task_names.uniq
+      tasks
     end
 
     def find_task
       task_name = params[:id].gsub('__', ':')
 
-      # Check if this is one of our allowed tasks (custom tasks + db:seed)
-      allowed_tasks = extract_task_names_from_files + ['db:seed']
-      return nil unless allowed_tasks.include?(task_name)
-
       # Ensure tasks are loaded
       Rails.application.load_tasks
 
       # Find the task
-      Rake::Task[task_name] rescue nil
+      task = Rake::Task[task_name] rescue nil
+      return nil unless task
+
+      # Check if it's db:seed or defined in lib/tasks
+      return task if task_name == 'db:seed'
+      return task if task_from_lib_tasks?(task)
+
+      nil
+    end
+
+    def task_from_lib_tasks?(task)
+      return false if task.actions.blank?
+
+      source_path = task.actions.first.source_location&.first
+      source_path.present? &&
+        source_path.include?(Rails.root.to_s) &&
+        source_path.include?('/lib/tasks/')
     end
   end
 end

--- a/lib/web_rake/version.rb
+++ b/lib/web_rake/version.rb
@@ -1,3 +1,3 @@
 module WebRake
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
Resolves #1 

## Problem

As we saw in class, the Regex checking for tasks is brittle.

## Solution

Refactor and remove the regexes.

## To Test

Boot up a codespace here: https://github.com/bp-demostudent-1/quizbot-deployment

Look at the tasks with various syntax defined in `lib/tasks/` (including one defined with `namespace` syntax)

Add a `.env`:

```
WEB_RAKE_USERNAME=admin
WEB_RAKE_PASSWORD=appdev
```

Visit `/rails/tasks`

All tasks are there and working.

The repo is deployed as well: https://my-app-name-7dgl.onrender.com/rails/tasks

(Username / Password: `admin` / `appdev`)

All tasks also visible and runnable on Render.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `TasksController` to remove regex-based task finding, using `Rake::Task` for task identification, and update version to `0.1.3`.
> 
>   - **Behavior**:
>     - Refactor `TasksController` to remove regex-based task finding, using `Rake::Task` to identify tasks in `lib/tasks` and `db:seed`.
>     - `execute` method now uses `find_task` for task validation.
>   - **Misc**:
>     - Update version in `version.rb` from `0.1.2` to `0.1.3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fweb_rake&utm_source=github&utm_medium=referral)<sup> for 620005900ace44c9a9ebe87f1cc1459706a51e62. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->